### PR TITLE
Fix incorrect start position when using high latency

### DIFF
--- a/PenPositionSim/DemoForm.cs
+++ b/PenPositionSim/DemoForm.cs
@@ -8,6 +8,7 @@ namespace PenPositionSim
         private MouseDataSource mds = new MouseDataSource();
 
         private bool isDrawing;
+        bool initialReport = true;
 
         EMASmoother smoother;
         private PointD reported_pos_prev;
@@ -49,6 +50,17 @@ namespace PenPositionSim
         private void update_reported_pos()
         {
             var mp = this.mds.GetMousePosition(this);
+            if (mp == Point.Empty)
+            {
+                return;
+            }
+            if (initialReport)
+            {
+                reported_pos_prev = Util.add(new PointD(mp), -inkCanvas.Left, -inkCanvas.Top);
+                smoothed_pos_prev = Util.add(new PointD(mp), -inkCanvas.Left, -inkCanvas.Top);
+                this.smoother.SetOldSmoothed(Util.add(new PointD(mp), -inkCanvas.Left, -inkCanvas.Top));
+                initialReport = false;
+            }
             reported_pos_cur = Util.add(new PointD(mp), -inkCanvas.Left, -inkCanvas.Top);
         }
 
@@ -63,7 +75,7 @@ namespace PenPositionSim
             var reported_rect = new Rectangle(reported_pos_cur.ToPointRounded(), point_rect_size);
             var smoothed_rect = new Rectangle(smoothed_pos_cur.ToPointRounded(), point_rect_size);
 
-            if (isDrawing)
+            if (isDrawing && !initialReport)
             {
                 using (Graphics g = inkCanvas.CreateGraphics())
                 {
@@ -114,9 +126,8 @@ namespace PenPositionSim
             if (e.Button == MouseButtons.Left)
             {
                 isDrawing = true;
-                reported_pos_prev = reported_pos_cur;
-                smoothed_pos_prev = reported_pos_cur;
-                this.smoother.SetOldSmoothed(reported_pos_cur);
+                initialReport = true;
+                mds.ClearQueue();
                 return;
             }
 

--- a/PenPositionSim/MouseDataSource.cs
+++ b/PenPositionSim/MouseDataSource.cs
@@ -29,9 +29,10 @@
             // the delay. return a fake value for until there is enough
             // in the queue
 
+            queue.Enqueue(GetMousePositionRaw(ctrl));
+
             if (queue.Count<this.posqueue_size) 
             {
-                queue.Enqueue(GetMousePositionRaw(ctrl));
                 return Point.Empty;
             }
 
@@ -39,13 +40,17 @@
             // reporting from the quque
 
             var p = queue.Dequeue();
-            queue.Enqueue(GetMousePositionRaw(ctrl));
             return p;
         }
 
         private static Point GetMousePositionRaw(Control ctrl)
         {
             return ctrl.PointToClient(Control.MousePosition);
+        }
+
+        public void ClearQueue()
+        {
+            this.queue = new Queue<Point>(this.posqueue_size);
         }
     }
 


### PR DESCRIPTION
Currently, when using high latency the start of the line is drawn starting from the wrong position. This can cause large jumps and weird lines especially on low report rate. It is mostly masked on higher report rates but still exists there too. This fixes that.